### PR TITLE
[FEAT] [HIGH-16] 컬러 시스템 구축 및 공통 버튼

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "frontend",
 			"version": "0.0.0",
 			"dependencies": {
+				"@radix-ui/react-slot": "^1.2.3",
 				"@tanstack/react-query": "^5.81.5",
 				"axios": "^1.10.0",
 				"class-variance-authority": "^0.7.1",
@@ -1616,6 +1617,39 @@
 				"url": "https://opencollective.com/pkgr"
 			}
 		},
+		"node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+			"integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-slot": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+			"integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@rolldown/pluginutils": {
 			"version": "1.0.0-beta.19",
 			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.19.tgz",
@@ -2037,7 +2071,7 @@
 			"version": "19.1.8",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
 			"integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"csstype": "^3.0.2"
@@ -3407,7 +3441,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
 			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/damerau-levenshtein": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"prepare": "husky install"
 	},
 	"dependencies": {
+		"@radix-ui/react-slot": "^1.2.3",
 		"@tanstack/react-query": "^5.81.5",
 		"axios": "^1.10.0",
 		"class-variance-authority": "^0.7.1",

--- a/src/components/common/CommonButton.tsx
+++ b/src/components/common/CommonButton.tsx
@@ -1,0 +1,47 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface CommonButtonProps {
+	text: string;
+	emoji?: string;
+	onClick?: () => void;
+	variant?:
+		| "default"
+		| "destructive"
+		| "outline"
+		| "secondary"
+		| "ghost"
+		| "link";
+	size?: "default" | "sm" | "lg" | "icon";
+	disabled?: boolean;
+	className?: string;
+}
+
+const CommonButton = ({
+	text,
+	emoji,
+	onClick,
+	variant = "default",
+	size = "default",
+	disabled = false,
+	className,
+}: CommonButtonProps) => {
+	return (
+		<Button
+			onClick={onClick}
+			variant={variant}
+			size={size}
+			disabled={disabled}
+			className={cn(
+				"h-12 w-80 text-base font-medium",
+				variant === "default" &&
+					"bg-custom-point text-custom-black hover:bg-custom-point/90",
+				className
+			)}>
+			{emoji && <span className="mr-2">{emoji}</span>}
+			{text}
+		</Button>
+	);
+};
+
+export default CommonButton;

--- a/src/components/common/CommonButton.tsx
+++ b/src/components/common/CommonButton.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import { cn } from "@/utils/cn";
 
 interface CommonButtonProps {
 	text: string;

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+	{
+		variants: {
+			variant: {
+				default:
+					"bg-primary text-primary-foreground shadow hover:bg-primary/90",
+				destructive:
+					"bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+				outline:
+					"border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+				secondary:
+					"bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+				ghost: "hover:bg-accent hover:text-accent-foreground",
+				link: "text-primary underline-offset-4 hover:underline",
+			},
+			size: {
+				default: "h-9 px-4 py-2",
+				sm: "h-8 rounded-md px-3 text-xs",
+				lg: "h-10 rounded-md px-8",
+				icon: "h-9 w-9",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+			size: "default",
+		},
+	}
+);
+
+export interface ButtonProps
+	extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+		VariantProps<typeof buttonVariants> {
+	asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+	({ className, variant, size, asChild = false, ...props }, ref) => {
+		const Comp = asChild ? Slot : "button";
+		return (
+			<Comp
+				className={cn(buttonVariants({ variant, size, className }))}
+				ref={ref}
+				{...props}
+			/>
+		);
+	}
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils";
+import { cn } from "@/utils/cn";
 
 const buttonVariants = cva(
 	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+	return twMerge(clsx(inputs));
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,0 @@
-import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs: ClassValue[]) {
-	return twMerge(clsx(inputs));
-}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -50,6 +50,12 @@ export default {
 					4: "hsl(var(--chart-4))",
 					5: "hsl(var(--chart-5))",
 				},
+				custom: {
+					black: "#141516",
+					point: "#40FEA4",
+					gray: "#A1A1A1",
+					darkgray: "#4A4949",
+				},
 			},
 		},
 	},


### PR DESCRIPTION
## ✨ PR 세부 내용

<!-- 이번 PR에서 작업한 내용을 설명해주세요. -->
<!-- 예시: 로그인 페이지 UI 구현 -->

###  컬러 시스템 구축
- Tailwind CSS에 커스텀 컬러 시스템 추가
- 브랜드 컬러: black (#141516), point (#40FEA4), gray (#A1A1A1), darkgray (#4A4949)
- custom 네임스페이스를 통한 오버라이드 방지
- 일관된 디자인 시스템 구축

### 공통 버튼 컴포넌트 제작
- Atomic Design 패턴을 따른 CommonButton 컴포넌트 구현
- shadcn/ui Button 컴포넌트 기반 확장
- 반응형 디자인 적용 (px 대신 Tailwind 클래스 사용)
- Props 기반 유연한 커스터마이징 지원
- 기본 색상을 포인트 컬러로 설정

## ☑️ 체크리스트

### 🛠 기본 검사 항목
- [X] ESLint 검사 완료
- [X] Prettier 적용

## 📸 스크린샷

<!-- 작성하지 않는다면 항목을 지워주세요. -->


## ✅ 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.  
작성하지 않는다면 항목을 지워주세요.  
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
1. 컬러 시스템 설계: 현재 설정한 커스텀 컬러 구조와 네이밍이 적절한지 검토 부탁드립니다.
2. CommonButton 컴포넌트: Props 설계와 기본 스타일링이 확장성과 재사용성이 용이한 지 검토해주세요
