### PR TITLE
[FEAT] [HIGH-55] QA 사항 반영: 홈페이지에서 상세 정보 프리패칭 및 디자인 수정

### DIFF
--- a/src/components/Home/atom/ContentCard.tsx
+++ b/src/components/Home/atom/ContentCard.tsx
@@ -1,13 +1,22 @@
 import LazyImage from "@/components/common/atom/LazyImage";
+import { usePrefetchContentOnView } from "@/hooks/common/usePrefetchContentOnView";
 
 interface ContentCardProps {
   thumbnailUrl: string;
+  contentId: string;
   width?: string;
 }
 
-const ContentCard = ({ thumbnailUrl, width = "w-full" }: ContentCardProps) => {
+const ContentCard = ({
+  thumbnailUrl,
+  contentId,
+  width = "w-full",
+}: ContentCardProps) => {
+  const { ref } = usePrefetchContentOnView(contentId);
+
   return (
     <div
+      ref={ref}
       className={`overflow-hidden rounded-xl aspect-[2/3] ${width} md:w-[10rem]`}>
       <LazyImage
         src={thumbnailUrl}

--- a/src/components/Home/molecule/RecommendationSection.tsx
+++ b/src/components/Home/molecule/RecommendationSection.tsx
@@ -31,7 +31,10 @@ const RecommendationSection = ({
             <Link
               to={PATH.CONTENT_DETAIL.replace(":id", String(content.contentId))}
               className="block focus:outline-none focus-visible:ring-2 ring-offset-2 ring-custom-point">
-              <ContentCard thumbnailUrl={content.thumbnailUrl} />
+              <ContentCard
+                thumbnailUrl={content.thumbnailUrl}
+                contentId={String(content.contentId)}
+              />
             </Link>
           </li>
         ))}

--- a/src/components/Home/organism/MainRecommendBanner.tsx
+++ b/src/components/Home/organism/MainRecommendBanner.tsx
@@ -63,13 +63,25 @@ const MainRecommendBanner = ({ content }: Props) => {
           <track kind="captions" />
         </video>
 
+        {/* {isPlaying && (
+          <div className="absolute inset-0 z-10 flex items-end justify-center">
+            <h1 className="text-white text-heading-h1 font-pretendard text-center">
+              {content.title}
+            </h1>
+          </div>
+        )} */}
         {isPlaying && (
-          <h1 className="absolute top-[2px] left-1 text-white text-body-lg md:text-heading-h1 font-bmDohyeon">
-            {content.title}
-          </h1>
+          <div className="absolute inset-0 z-10 flex flex-col items-center justify-end pb-2 text-center px-4">
+            <h1 className="text-white text-heading-h1 font-pretendard">
+              {content.title}
+            </h1>
+            <p className="text-body-xs md:text-body-sm text-custom-gray ">
+              {content.genre.join(" · ")}
+            </p>
+          </div>
         )}
 
-        <div className="absolute bottom-2 right-2 z-10">
+        <div className="absolute bottom-0 right-2 z-10">
           <Button
             variant="ghost"
             onClick={toggleMute}
@@ -82,7 +94,7 @@ const MainRecommendBanner = ({ content }: Props) => {
           </Button>
         </div>
 
-        <div className="absolute bottom-0 left-0 w-full h-24 bg-gradient-to-b from-transparent to-custom-black" />
+        <div className="absolute bottom-0 left-0 w-full h-40 bg-gradient-to-b from-transparent to-custom-black" />
       </div>
 
       {!isPlaying && (
@@ -95,9 +107,6 @@ const MainRecommendBanner = ({ content }: Props) => {
               </span>
             ))}
           </h2>
-          <p className="text-body-xs md:text-body-sm text-custom-gray font-pretendard">
-            {content.genre.join(" · ")}
-          </p>
         </div>
       )}
     </section>

--- a/src/components/Home/organism/MainRecommendBanner.tsx
+++ b/src/components/Home/organism/MainRecommendBanner.tsx
@@ -63,13 +63,6 @@ const MainRecommendBanner = ({ content }: Props) => {
           <track kind="captions" />
         </video>
 
-        {/* {isPlaying && (
-          <div className="absolute inset-0 z-10 flex items-end justify-center">
-            <h1 className="text-white text-heading-h1 font-pretendard text-center">
-              {content.title}
-            </h1>
-          </div>
-        )} */}
         {isPlaying && (
           <div className="absolute inset-0 z-10 flex flex-col items-center justify-end pb-2 text-center px-4">
             <h1 className="text-white text-heading-h1 font-pretendard">

--- a/src/components/Home/organism/MainRecommendBanner.tsx
+++ b/src/components/Home/organism/MainRecommendBanner.tsx
@@ -65,7 +65,7 @@ const MainRecommendBanner = ({ content }: Props) => {
 
         {isPlaying && (
           <div className="absolute inset-0 z-10 flex flex-col items-center justify-end pb-2 text-center px-4">
-            <h1 className="text-white text-heading-h1 font-pretendard">
+            <h1 className="text-white text-heading-h2 font-pretendard">
               {content.title}
             </h1>
             <p className="text-body-xs md:text-body-sm text-custom-gray ">
@@ -100,6 +100,9 @@ const MainRecommendBanner = ({ content }: Props) => {
               </span>
             ))}
           </h2>
+          <p className="text-body-xs md:text-body-sm text-custom-gray ">
+            {content.genre.join(" · ")}
+          </p>
         </div>
       )}
     </section>

--- a/src/components/contentDetail/ContentDetailLayout.tsx
+++ b/src/components/contentDetail/ContentDetailLayout.tsx
@@ -46,6 +46,7 @@ const ContentDetailLayout = ({
       aria-label="콘텐츠 상세 정보">
       <ContentVideo
         videoUrl={content.videoUrl}
+        posterUrl={content.posterUrl}
         isMuted={isMuted}
         contentTitle={content.contentTitle}
       />

--- a/src/components/contentDetail/organism/ContentVideo.tsx
+++ b/src/components/contentDetail/organism/ContentVideo.tsx
@@ -1,19 +1,23 @@
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import clsx from "clsx";
 import { useAutoPlayVideo } from "@/hooks/common/useAutoPlayVideo";
 
 interface ContentVideoProps {
   videoUrl: string;
+  posterUrl: string;
   isMuted?: boolean;
   contentTitle?: string;
 }
 
 const ContentVideo = ({
   videoUrl,
+  posterUrl,
   isMuted = true,
   contentTitle = "콘텐츠",
 }: ContentVideoProps) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const [isVideoReady, setIsVideoReady] = useState(false);
 
   useAutoPlayVideo({
     videoRef,
@@ -21,10 +25,29 @@ const ContentVideo = ({
     videoUrl,
   });
 
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    const handleCanPlay = () => setIsVideoReady(true);
+    video.addEventListener("canplay", handleCanPlay);
+    // eslint-disable-next-line consistent-return
+    return () => video.removeEventListener("canplay", handleCanPlay);
+  }, []);
+
   return (
     <div
       ref={containerRef}
-      className="fixed top-0 left-1/2 -translate-x-1/2 max-w-[768px] w-full aspect-[16/9] z-0">
+      className="fixed top-0 left-1/2 -translate-x-1/2 max-w-[768px] w-full aspect-[16/9] z-0 overflow-hidden">
+      <img
+        src={posterUrl}
+        alt={`${contentTitle} 포스터`}
+        className={clsx(
+          "absolute w-full h-full object-cover transition-opacity duration-700",
+          isVideoReady ? "opacity-0" : "opacity-100"
+        )}
+      />
+
       <video
         ref={videoRef}
         className="w-full h-full object-cover"
@@ -32,14 +55,17 @@ const ContentVideo = ({
         playsInline
         loop
         controls={false}
+        preload="metadata"
         aria-label={`${contentTitle} 예고편 영상`}
         aria-describedby="video-description">
         <track kind="captions" />
       </video>
+
       <div id="video-description" className="sr-only">
         {contentTitle}의 예고편이 재생되고 있습니다. 음소거 상태는{" "}
         {isMuted ? "켜져" : "꺼져"} 있습니다.
       </div>
+
       <div className="absolute bottom-0 left-0 w-full h-40 bg-gradient-to-b from-transparent via-custom-black/30 to-custom-black" />
     </div>
   );

--- a/src/hooks/common/usePrefetchContentOnView.ts
+++ b/src/hooks/common/usePrefetchContentOnView.ts
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { getContentDetail } from "@/apis/content/getContentDetail";
+import { getContentReviews } from "@/apis/content/getContentReview";
+import { getMyReview } from "@/apis/content/getMyReview";
+import { useLazyIntersectionObserver } from "@/hooks/common/useLazyIntersectionObserver";
+import type { ReviewListResponse } from "@/types/content";
+
+export const usePrefetchContentOnView = (contentId: string) => {
+  const queryClient = useQueryClient();
+
+  const { ref, isIntersecting } = useLazyIntersectionObserver({
+    threshold: 0.1,
+    rootMargin: "100px",
+    triggerOnce: true,
+  });
+
+  useEffect(() => {
+    if (!isIntersecting) return;
+
+    queryClient.prefetchQuery({
+      queryKey: ["contentDetail", contentId],
+      queryFn: () => getContentDetail(contentId),
+      staleTime: 10 * 60 * 1000,
+    });
+
+    queryClient.prefetchInfiniteQuery({
+      queryKey: ["contentReviews", contentId],
+      queryFn: ({ pageParam = "" }) =>
+        getContentReviews(contentId, pageParam, 5),
+      initialPageParam: "",
+      getNextPageParam: (lastPage: ReviewListResponse) =>
+        lastPage.hasNext ? (lastPage.nextCursor ?? "") : undefined,
+      staleTime: 10 * 60 * 1000,
+    });
+
+    queryClient.prefetchQuery({
+      queryKey: ["myReview", contentId],
+      queryFn: () => getMyReview(contentId),
+      staleTime: 10 * 60 * 1000,
+    });
+  }, [isIntersecting, contentId]);
+
+  return { ref };
+};

--- a/src/hooks/queries/content/useContentDetailQuery.ts
+++ b/src/hooks/queries/content/useContentDetailQuery.ts
@@ -10,6 +10,7 @@ export const useContentDetailQuery = (contentId: string) => {
       }
       return getContentDetail(contentId);
     },
+    staleTime: 60 * 60 * 1000,
     retry: false,
   });
 

--- a/src/hooks/queries/content/useInfiniteContentReviewsQuery.ts
+++ b/src/hooks/queries/content/useInfiniteContentReviewsQuery.ts
@@ -14,6 +14,7 @@ export const useInfiniteContentReviewsQuery = (
       initialPageParam: "",
       getNextPageParam: (lastPage) =>
         lastPage.hasNext ? (lastPage.nextCursor ?? "") : undefined,
+      staleTime: 60 * 60 * 1000,
       enabled: !!contentId,
     });
 

--- a/src/hooks/queries/content/useMyReviewQuery.ts
+++ b/src/hooks/queries/content/useMyReviewQuery.ts
@@ -5,6 +5,7 @@ export const useMyReviewQuery = (contentId: string) => {
   const { data: myReview } = useSuspenseQuery({
     queryKey: ["myReview", contentId],
     queryFn: () => getMyReview(contentId),
+    staleTime: 60 * 60 * 1000,
   });
 
   return { myReview };


### PR DESCRIPTION
### **User description**
## ✨ PR 세부 내용

피드백 받은 내용을 개선했고 아래와 같습니다.

UX 개선을 위해 홈 진입 시 바로 보이는 콘텐츠는 즉시 프리패치(상세 정보/리뷰/내 리뷰, 이후 스크롤 진입 시점에 프리패치 트리거되도록 구성했습니다.

프리패칭한 데이터는 짧은 유효기간만 유지하였고 사용자가 한 번 본 콘텐츠는 오래 신선하게 유지하여 UX 개선 및 중복 요청을 방지하였습니다.

홈 UI 제목 위치 개선 및 상세페이지에도 포스터 이미지를 추가하고 영상으로 부드럽게 넘어가도록 개선하였습니다.

## ☑️ 체크리스트

### 🛠 기본 검사 항목

- [ ] ESLint 검사 완료
- [ ] Prettier 적용
- [ ] 함수, 변수, 파일 네이밍 검토
- [ ] 코드 작성 순서 (import, 내부 코드) 점검
- [ ] 폴더 구조에 맞는 파일 분리 여부 확인
- [ ] 코드 작성 스타일 점검

### ✍️ 작성자 선택 항목

<!-- 작성하지 않는다면 항목을 지워주세요. -->
<!-- - [ ] 폴더 구조에 맞게 컴포넌트/로직을 적절히 분리함 -->

## 📸 스크린샷

<!-- 작성하지 않는다면 항목을 지워주세요. -->

## ✅ 리뷰 요구사항

기존에 홈에 진입시 모든 상세 정보를 프리패칭 적용했으나 프리패칭 시점이 홈 영상 재생시점과 겹쳐 병렬 fetch + 렌더 + HLS 영상까지 동시에 돌면 병목이 생겨 IntersectionObserver 기반 분산 처리 방식으로 변경하였습니다. 더 좋은 방법이 있다면 알려주시면 감사하겠습니다


___

### **PR Type**
Enhancement


___

### **Description**
- Add usePrefetchContentOnView hook for lazy prefetch

- Integrate hook into ContentCard for thumbnails

- Pass `contentId` in RecommendationSection

- Set 1h staleTime for content queries


___

### Diagram Walkthrough


```mermaid
flowchart LR
  C["ContentCard"] -- "uses" --> O["usePrefetchContentOnView"]
  O -- "onIntersect" --> PQ["prefetchQuery: contentDetail"]
  O -- "onIntersect" --> PR["prefetchInfiniteQuery: contentReviews"]
  O -- "onIntersect" --> PM["prefetchQuery: myReview"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ContentCard.tsx</strong><dd><code>Integrate prefetch hook in ContentCard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/Home/atom/ContentCard.tsx

<ul><li>Added <code>contentId</code> prop<br> <li> Imported <code>usePrefetchContentOnView</code> hook<br> <li> Attached <code>ref</code> for lazy prefetch</ul>


</details>


  </td>
  <td><a href="https://github.com/Ureka-High-Five/frontend/pull/51/files#diff-708a56b4987835298146098b2f37844f198f38b72ecbc4917faa80230c64d2f7">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RecommendationSection.tsx</strong><dd><code>Pass contentId prop in recommendations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/Home/molecule/RecommendationSection.tsx

<ul><li>Passed <code>contentId</code> to <code>ContentCard</code><br> <li> Updated component usage with new prop</ul>


</details>


  </td>
  <td><a href="https://github.com/Ureka-High-Five/frontend/pull/51/files#diff-55e7df087e91264960364e73627e54bc68350be91e0ae521fe20992030ad152a">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>usePrefetchContentOnView.ts</strong><dd><code>New hook for on-view content prefetch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks/common/usePrefetchContentOnView.ts

<ul><li>Created hook utilizing IntersectionObserver<br> <li> Prefetch content detail, reviews, my review<br> <li> Configured staleTime and trigger once</ul>


</details>


  </td>
  <td><a href="https://github.com/Ureka-High-Five/frontend/pull/51/files#diff-cbb7cdebe4beb071ba3fc66012a28c0a30feb315f9cb8e3b8b6b3e779bc7635a">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useContentDetailQuery.ts</strong><dd><code>Increase staleTime for detail query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks/queries/content/useContentDetailQuery.ts

- Added `staleTime: 1h` option
- Ensures cached detail data longevity


</details>


  </td>
  <td><a href="https://github.com/Ureka-High-Five/frontend/pull/51/files#diff-2d70a945492d93105129edc0c0acbc5203a3ee6678e868ffdd661f7ce36d28a6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useInfiniteContentReviewsQuery.ts</strong><dd><code>Increase staleTime for reviews query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks/queries/content/useInfiniteContentReviewsQuery.ts

<ul><li>Added <code>staleTime: 1h</code> to infinite reviews query<br> <li> Improves caching for review pagination</ul>


</details>


  </td>
  <td><a href="https://github.com/Ureka-High-Five/frontend/pull/51/files#diff-4a0f0871b7f55dadae0e0198405439c9ec44ffdaa02fcc5d6411f3129228f408">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useMyReviewQuery.ts</strong><dd><code>Increase staleTime for myReview query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks/queries/content/useMyReviewQuery.ts

<ul><li>Added <code>staleTime: 1h</code> to myReview query<br> <li> Enhances cache duration for user review</ul>


</details>


  </td>
  <td><a href="https://github.com/Ureka-High-Five/frontend/pull/51/files#diff-a5be4e767f87eae83b78fc247b0917f51d1ff890dd6498bbfa1cbd7d7ef69762">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

