### PR TITLE
[FEAT] [HIGH-68] 쇼츠, 모달 QA 수정 및 금칙어 검사

### DIFF
--- a/src/apis/onboarding/postSlangCheck.ts
+++ b/src/apis/onboarding/postSlangCheck.ts
@@ -1,0 +1,19 @@
+import { axiosInstance } from "@/apis/axiosInstance";
+import { END_POINTS } from "@/constants/api";
+import type { SlangCheckResponse } from "@/types/onBoarding";
+
+const postSlangCheck = async (text: string): Promise<SlangCheckResponse> => {
+  const response = await axiosInstance.post(
+    END_POINTS.SLANG_FILTER,
+    {
+      text,
+    },
+    {
+      isAuthRequired: false,
+    }
+  );
+
+  return response.data.content;
+};
+
+export default postSlangCheck;

--- a/src/components/My/organism/CreateCurationModal.tsx
+++ b/src/components/My/organism/CreateCurationModal.tsx
@@ -5,6 +5,7 @@ import SearchContentList from "@/components/My/molecule/SearchContentList";
 import SelectedContentList from "@/components/My/molecule/SelectedContentList";
 import { Button } from "@/components/ui/button";
 import { ONBOARDING_SEARCH_COUNT } from "@/constants/onBoarding";
+import useOutsideClick from "@/hooks/common/useOutsideClick";
 import useContentSelector from "@/hooks/my/useContentSelector";
 import useCurationSubmit from "@/hooks/my/useCurationSubmit";
 import { useSearchContent } from "@/hooks/onboarding/useSearchContent";
@@ -19,6 +20,7 @@ const CreateCurationModal = ({ onClose }: CreateCurationModalProps) => {
   const titleRef = useRef<HTMLInputElement>(null);
   const descriptionRef = useRef<HTMLTextAreaElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const outsideRef = useOutsideClick({ onClickOutside: onClose });
 
   const { contentId, selectedContents, toggleSelect } = useContentSelector();
   const { handleSubmit } = useCurationSubmit({
@@ -45,7 +47,9 @@ const CreateCurationModal = ({ onClose }: CreateCurationModalProps) => {
       role="dialog"
       aria-labelledby="curation-modal-title"
       className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center px-4 sm:px-6 py-10">
-      <div className="flex flex-col gap-4 bg-custom-darkgray w-[90%] max-w-md max-h-full overflow-y-auto no-scrollbar rounded-md p-6 relative">
+      <div
+        ref={outsideRef}
+        className="flex flex-col gap-4 bg-custom-darkgray w-[90%] max-w-md max-h-full overflow-y-auto no-scrollbar rounded-md p-6 relative">
         <button
           type="button"
           onClick={onClose}

--- a/src/components/OnBoarding/OnBoardingLayout.tsx
+++ b/src/components/OnBoarding/OnBoardingLayout.tsx
@@ -14,6 +14,9 @@ interface OnBoardingLayoutProps {
   selectedContents: OnBoardingContent[];
   toggleSelect: (content: OnBoardingContent) => void;
   onSubmitOnBoarding: () => void;
+  nameInputRef: React.RefObject<HTMLInputElement | null>;
+  hasNameError: boolean;
+  setHasNameError: (hasError: boolean) => void;
 }
 
 const OnBoardingLayout = ({
@@ -24,6 +27,9 @@ const OnBoardingLayout = ({
   selectedContents,
   toggleSelect,
   onSubmitOnBoarding,
+  nameInputRef,
+  hasNameError,
+  setHasNameError,
 }: OnBoardingLayoutProps) => {
   const selectedCount = selectedIds.length;
 
@@ -53,11 +59,22 @@ const OnBoardingLayout = ({
         />
       ) : (
         <>
-          <Name setStep={setStep} isActive={step === "name"} />
+          <Name
+            setStep={setStep}
+            isActive={step === "name"}
+            nameInputRef={nameInputRef}
+            hasNameError={hasNameError}
+          />
           {(step === "birthYear" || step === "gender") && (
             <BirthYearSelect setStep={setStep} />
           )}
-          {step === "gender" && <GenderSelect setStep={setStep} />}
+          {step === "gender" && (
+            <GenderSelect
+              setStep={setStep}
+              nameInputRef={nameInputRef}
+              setHasNameError={setHasNameError}
+            />
+          )}
         </>
       )}
     </section>

--- a/src/components/OnBoarding/organism/GenderSelect.tsx
+++ b/src/components/OnBoarding/organism/GenderSelect.tsx
@@ -6,24 +6,54 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select";
+import useSlangCheckMutation from "@/hooks/queries/onboarding/useSlangCheckMutation";
 import useUserStore from "@/stores/useUserStore";
 import { cn } from "@/utils/cn";
+import { makeToast } from "@/utils/makeToast";
 import type { OnBoardingStep } from "@/types/onBoarding";
 
 interface GenderSelectProps {
   setStep: (step: OnBoardingStep) => void;
+  nameInputRef: React.RefObject<HTMLInputElement | null>;
+  setHasNameError: (hasError: boolean) => void;
 }
 
-const GenderSelect = ({ setStep }: GenderSelectProps) => {
+const GenderSelect = ({
+  setStep,
+  nameInputRef,
+  setHasNameError,
+}: GenderSelectProps) => {
   const gender = useUserStore((state) => state.user.gender);
   const name = useUserStore((state) => state.user.name);
   const birthYear = useUserStore((state) => state.user.birthYear);
   const setGender = useUserStore((state) => state.setGender);
 
+  const { mutateSlangCheck } = useSlangCheckMutation();
+
+  const handleNextClick = async () => {
+    try {
+      const result = await mutateSlangCheck(name);
+
+      if (result.slangFlag) {
+        setHasNameError(true);
+        nameInputRef.current?.focus();
+
+        return;
+      }
+
+      setStep("content");
+    } catch (error) {
+      makeToast(
+        "이름 확인 중 문제가 발생했어요. 잠시 후 다시 시도해주세요.",
+        "warning"
+      );
+    }
+  };
+
   return (
     <section
       aria-labelledby="gender-select-heading"
-      className="flex flex-col gap-9 w-[90%] max-w-sm">
+      className="flex flex-col gap-4 w-[90%] max-w-sm">
       <h2 id="gender-select-heading" className="sr-only">
         성별 선택
       </h2>
@@ -47,7 +77,7 @@ const GenderSelect = ({ setStep }: GenderSelectProps) => {
       <Button
         size="lg"
         className="w-full bg-custom-point text-custom-black body-lg-dohyeon hover:bg-custom-point/90 hover:text-custom-black disabled:opacity-50 disabled:cursor-not-allowed"
-        onClick={() => setStep("content")}
+        onClick={handleNextClick}
         disabled={!(gender && name && birthYear)}>
         다음으로
       </Button>

--- a/src/components/OnBoarding/organism/Name.tsx
+++ b/src/components/OnBoarding/organism/Name.tsx
@@ -6,9 +6,11 @@ import type { OnBoardingStep } from "@/types/onBoarding";
 interface NameProps {
   setStep: (step: OnBoardingStep) => void;
   isActive: boolean;
+  nameInputRef: React.RefObject<HTMLInputElement | null>;
+  hasNameError: boolean;
 }
 
-const Name = ({ setStep, isActive }: NameProps) => {
+const Name = ({ setStep, isActive, nameInputRef, hasNameError }: NameProps) => {
   const name = useUserStore((state) => state.user.name);
   const setName = useUserStore((state) => state.setName);
 
@@ -23,17 +25,28 @@ const Name = ({ setStep, isActive }: NameProps) => {
       <h2 id="name-heading" className="sr-only">
         이름 확인
       </h2>
-      <Input
-        className={`h-14 bg-white !text-heading-h1 font-pretendard text-center leading-[5rem] px-4 rounded-md 
+      <div className="flex flex-col gap-2">
+        <Input
+          ref={nameInputRef}
+          className={`h-14 bg-white !text-heading-h1 font-pretendard text-center leading-[5rem] px-4 rounded-md 
           focus:border-2 focus:border-custom-point focus:border-2 focus:border-custom-point ${
             isActive
               ? "border-2 border-custom-point"
               : "border border-transparent"
           }`}
-        placeholder="이름을 작성해주세요"
-        value={name}
-        onChange={handleNameChange}
-      />
+          placeholder="이름을 작성해주세요"
+          value={name}
+          onChange={handleNameChange}
+        />
+        {hasNameError && (
+          <p
+            className="text-body-md text-red-500"
+            role="alert"
+            aria-live="polite">
+            이름에 사용할 수 없는 단어가 있어요.
+          </p>
+        )}
+      </div>
 
       {isActive && (
         <Button

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -27,6 +27,7 @@ export const END_POINTS = {
   SHORTS_COMMENT_TIMELINE: (shortsId: number) => `/shorts/${shortsId}/comments`,
   WATCH_LOG: "content/watch-log",
   USER_REVIEW: "user/reviews",
+  SLANG_FILTER: "slang/filter",
 } as const;
 
 export const NETWORK_TIMEOUT = 30000;

--- a/src/hooks/common/useOutsideClick.ts
+++ b/src/hooks/common/useOutsideClick.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useRef } from "react";
+
+interface UseOutsideClickProps {
+  onClickOutside: () => void;
+}
+
+const useOutsideClick = ({ onClickOutside }: UseOutsideClickProps) => {
+  const outsideRef = useRef<HTMLDivElement | null>(null);
+
+  const handleClickOutside = useCallback(
+    (event: MouseEvent) => {
+      const inside = outsideRef.current?.contains(event.target as Node);
+
+      if (outsideRef.current && !inside) {
+        onClickOutside();
+      }
+    },
+
+    [onClickOutside]
+  );
+
+  useEffect(() => {
+    document.addEventListener("mouseup", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mouseup", handleClickOutside);
+    };
+  }, [handleClickOutside]);
+
+  return outsideRef;
+};
+
+export default useOutsideClick;

--- a/src/hooks/queries/onboarding/useSlangCheckMutation.ts
+++ b/src/hooks/queries/onboarding/useSlangCheckMutation.ts
@@ -1,0 +1,14 @@
+import { useMutation } from "@tanstack/react-query";
+import postSlangCheck from "@/apis/onboarding/postSlangCheck";
+
+const useSlangCheckMutation = () => {
+  const { mutateAsync: mutateSlangCheck } = useMutation({
+    mutationFn: postSlangCheck,
+  });
+
+  return {
+    mutateSlangCheck,
+  };
+};
+
+export default useSlangCheckMutation;

--- a/src/hooks/queries/shorts/useShortsInfiniteQuery.ts
+++ b/src/hooks/queries/shorts/useShortsInfiniteQuery.ts
@@ -7,9 +7,10 @@ export const useShortsInfiniteQuery = () => {
     useSuspenseInfiniteQuery<GetShortsResponse>({
       queryKey: ["shorts"],
       queryFn: ({ pageParam = null }) =>
-        getShorts({ cursor: pageParam as number | undefined }),
-      getNextPageParam: (lastPage) =>
-        lastPage.hasNext ? lastPage.nextCursor : undefined,
+        getShorts({ cursor: pageParam as number }),
+      getNextPageParam: (lastPage) => {
+        return lastPage.nextCursor === null ? 0 : lastPage.nextCursor;
+      },
       initialPageParam: null,
       staleTime: 60 * 1000,
     });

--- a/src/pages/OnBoardingPage.tsx
+++ b/src/pages/OnBoardingPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import OnBoardingLayout from "@/components/OnBoarding/OnBoardingLayout";
 import useOnBoardingContentMutation from "@/hooks/queries/onboarding/useOnBoardingContentMutation";
 import useOnBoardingContentQuery from "@/hooks/queries/onboarding/useOnBoardingContentQuery";
@@ -13,6 +13,8 @@ const OnBoardingPage = () => {
   const [selectedContents, setSelectedContents] = useState<OnBoardingContent[]>(
     []
   );
+  const [hasNameError, setHasNameError] = useState(false);
+  const nameInputRef = useRef<HTMLInputElement>(null);
 
   const selectedIds = useUserStore((state) => state.user.selectedContentIds);
   const addContentId = useUserStore((state) => state.addSelectedContentId);
@@ -66,6 +68,9 @@ const OnBoardingPage = () => {
       selectedContents={selectedContents}
       toggleSelect={toggleSelect}
       onSubmitOnBoarding={handleSubmitOnBoarding}
+      nameInputRef={nameInputRef}
+      hasNameError={hasNameError}
+      setHasNameError={setHasNameError}
     />
   );
 };

--- a/src/types/onBoarding.d.ts
+++ b/src/types/onBoarding.d.ts
@@ -1,1 +1,5 @@
 export type OnBoardingStep = "name" | "birthYear" | "gender" | "content";
+
+export interface SlangCheckResponse {
+  slangFlag: boolean;
+}


### PR DESCRIPTION
### **User description**
## ✨ PR 세부 내용

<!-- 이번 PR에서 작업한 내용을 설명해주세요. -->
<!-- 예시: 로그인 페이지 UI 구현 -->

- 사용자 이름 금칙어 검사 로직 구현  
- 외부 클릭 감지를 위한 공통 useOutsideClick 훅 구현  
- 쇼츠 영상 무한 스크롤 강제 지속 처리 추가

## ☑️ 체크리스트

### 🛠 기본 검사 항목

- [x] ESLint 검사 완료
- [x] Prettier 적용
- [x] 함수, 변수, 파일 네이밍 검토
- [x] 코드 작성 순서 (import, 내부 코드) 점검
- [x] 폴더 구조에 맞는 파일 분리 여부 확인
- [x] 코드 작성 스타일 점검

## 📸 스크린샷

<!-- 작성하지 않는다면 항목을 지워주세요. -->
<img width="959" height="863" alt="image" src="https://github.com/user-attachments/assets/7f14a8bb-2a86-4fdd-8516-70296063eefc" />

## ✅ 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
작성하지 않는다면 항목을 지워주세요.
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

사용자 이름 금칙어에 대한 에러 메시지를 이름 입력창 하단에 표시하는 것과 다음 버튼 근처에 표시하는 것 중, UX적으로 어떤 위치가 더 적절한지 조언해주시면 감사하겠습니다.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add API call and mutation for name profanity check

- Display error and block next on reserved names

- Implement outside-click hook for modal closure

- Fix infinite scroll by treating null cursor as zero


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

</details>

___

